### PR TITLE
Avoid messages "Ip address not defined for poller" in centcore.log

### DIFF
--- a/service-monitoring/src/action.php
+++ b/service-monitoring/src/action.php
@@ -250,15 +250,16 @@ try {
                 }
                 $hostId = $tmp[0];
                 $svcId = $tmp[1];
-                if ($hostId == 0 && $svcId == 0) continue;
-                $hostname = $hostObj->getHostName($hostId);
-                $svcDesc = $svcObj->getServiceDesc($svcId);
-                if ($isSvcCommand === true) {
-                    $cmdParam = $hostname . ";" . $svcDesc;
-                } else {
-                    $cmdParam = $hostname;
+                if ($hostId != 0 && $svcId != 0) {
+                    $hostname = $hostObj->getHostName($hostId);
+                    $svcDesc = $svcObj->getServiceDesc($svcId);
+                    if ($isSvcCommand === true) {
+                        $cmdParam = $hostname . ";" . $svcDesc;
+                    } else {
+                        $cmdParam = $hostname;
+                    }
+                    $externalCmd->$externalCommandMethod(sprintf($command, $cmdParam), $hostObj->getHostPollerId($hostId));
                 }
-                $externalCmd->$externalCommandMethod(sprintf($command, $cmdParam), $hostObj->getHostPollerId($hostId));
             }
             $externalCmd->write();
         }

--- a/service-monitoring/src/action.php
+++ b/service-monitoring/src/action.php
@@ -250,6 +250,7 @@ try {
                 }
                 $hostId = $tmp[0];
                 $svcId = $tmp[1];
+                if ($hostId == 0 && $svcId == 0) continue;
                 $hostname = $hostObj->getHostName($hostId);
                 $svcDesc = $svcObj->getServiceDesc($svcId);
                 if ($isSvcCommand === true) {

--- a/service-monitoring/src/sendCmd.php
+++ b/service-monitoring/src/sendCmd.php
@@ -132,27 +132,28 @@ try {
             }
             $hostId = $tmp[0];
             $svcId = $tmp[1];
-            if ($hostId == 0 && $svcId == 0) continue;
-            $hostname = $hostObj->getHostName($hostId);
-            $svcDesc = $svcObj->getServiceDesc($svcId);
-            $pollerId = $hostObj->getHostPollerId($hostId);
-            if ($cmd == 70 || $cmd == 74) {
-                $externalCmd->$externalCommandMethod(sprintf($commandSvc, $hostname, $svcDesc), $pollerId);
-                if (isset($forceCmdSvc)) {
-                    $externalCmd->$externalCommandMethod(sprintf($forceCmdSvc, $hostname, $svcDesc), $pollerId);
-                }
-            } else {
-                $externalCmd->$externalCommandMethod(sprintf($command, $hostname), $pollerId);
-            }
-            if (isset($forceCmd)) {
-                $externalCmd->$externalCommandMethod(sprintf($forceCmd, $hostname), $pollerId);
-            }
-            if (isset($_POST['processServices'])) {
-                $services = $svcObj->getServiceId(null, $hostname);
-                foreach($services as $svcDesc => $svcId) {
+            if ($hostId != 0 && $svcId != 0) {
+                $hostname = $hostObj->getHostName($hostId);
+                $svcDesc = $svcObj->getServiceDesc($svcId);
+                $pollerId = $hostObj->getHostPollerId($hostId);
+                if ($cmd == 70 || $cmd == 74) {
                     $externalCmd->$externalCommandMethod(sprintf($commandSvc, $hostname, $svcDesc), $pollerId);
                     if (isset($forceCmdSvc)) {
                         $externalCmd->$externalCommandMethod(sprintf($forceCmdSvc, $hostname, $svcDesc), $pollerId);
+                    }
+                } else {
+                    $externalCmd->$externalCommandMethod(sprintf($command, $hostname), $pollerId);
+                }
+                if (isset($forceCmd)) {
+                    $externalCmd->$externalCommandMethod(sprintf($forceCmd, $hostname), $pollerId);
+                }
+                if (isset($_POST['processServices'])) {
+                    $services = $svcObj->getServiceId(null, $hostname);
+                    foreach($services as $svcDesc => $svcId) {
+                        $externalCmd->$externalCommandMethod(sprintf($commandSvc, $hostname, $svcDesc), $pollerId);
+                        if (isset($forceCmdSvc)) {
+                            $externalCmd->$externalCommandMethod(sprintf($forceCmdSvc, $hostname, $svcDesc), $pollerId);
+                        }
                     }
                 }
             }

--- a/service-monitoring/src/sendCmd.php
+++ b/service-monitoring/src/sendCmd.php
@@ -132,6 +132,7 @@ try {
             }
             $hostId = $tmp[0];
             $svcId = $tmp[1];
+            if ($hostId == 0 && $svcId == 0) continue;
             $hostname = $hostObj->getHostName($hostId);
             $svcDesc = $svcObj->getServiceDesc($svcId);
             $pollerId = $hostObj->getHostPollerId($hostId);


### PR DESCRIPTION
Hello,

**Step to reproduce:**
* Select all lines with the all selection button
* Execute an action on this selection
* Message "Ip address not defined for poller" is displayed in centcore.log

**Reason:**
The first selection which include the column name is considered as a monitoring line. The widget will try to send action on this line.

Thanks.