### PR TITLE
Update data_js.js

### DIFF
--- a/service-monitoring/src/data_js.js
+++ b/service-monitoring/src/data_js.js
@@ -56,7 +56,8 @@ jQuery(function () {
 	    icn = 's';
 	}
         
-	jQuery("[name="+tmp[0]+"]").append('<span style="position: relative; float: right;" class="ui-icon ui-icon-triangle-1-'+icn+'"></span>');
+	if(orderby)
+	    jQuery("[name="+tmp[0]+"]").append('<span style="position: relative; float: right;" class="ui-icon ui-icon-triangle-1-'+icn+'"></span>');
 
 	function paginationCallback(page_index, jq)
 	{


### PR DESCRIPTION
workaround for https://github.com/centreon/centreon/issues/4871

when orderby is null causes the following error:
![image](https://user-images.githubusercontent.com/25208457/41304874-b6b75c7c-6e47-11e8-9a42-eef6563c8c81.png)

steps to reproduce:
Enable pagination on service-monitoring-widget 1.6.2 without orderby. That will call data_js.js generating jquery errors which prevents widget to get proper resize in dashboard view
