### PR TITLE
fix(downtime popup): Fix popup does not close

### DIFF
--- a/service-monitoring/src/action.php
+++ b/service-monitoring/src/action.php
@@ -296,7 +296,7 @@ try {
 
     function closeBox()
     {
-        parent.jQuery('#widgetPopin').centreonPopin('close');
+        jQuery('#widgetPopin').centreonPopin('close');
     }
 
     function reloadFrame(widgetName) {


### PR DESCRIPTION
The downtime popup does not close when we click on the 'Set Downtime' button.