### PR TITLE
enh(UI): Option to hide chart link/icon

### DIFF
--- a/service-monitoring/configs.xml
+++ b/service-monitoring/configs.xml
@@ -45,6 +45,7 @@
     <preference label="Display Severities" name="display_severities" defaultValue="1" type="boolean" header="Columns"/>
     <preference label="Display Host Name" name="display_host_name" defaultValue="1" type="boolean" />
     <preference label="Display Host Alias" name="display_host_alias" defaultValue="0" type="boolean" />
+    <preference label="Display Chart Link/Icon" name="display_chart_icon" defaultValue="1" type="boolean"/>
     <preference label="Display Service Description" name="display_svc_description" defaultValue="1" type="boolean"/>
     <preference label="Display Output" name="display_output" defaultValue="1" type="boolean"/>
     <preference label="Output Length" name="output_length" defaultValue="50" type="range" min="50" max="500" step="50"/>

--- a/service-monitoring/src/table.ihtml
+++ b/service-monitoring/src/table.ihtml
@@ -91,7 +91,7 @@
 		        {/if}
 		        {if $preferences.display_svc_description}
 	                <td class=''>
-			{if $elem.perfdata != ""}
+			{if $preferences.display_chart_icon && $elem.perfdata != ""}
 			    <a target=_blank href='{$centreon_web_path}main.php?p=204&amp;mode=0&svc_id={$elem.encoded_hostname};{$elem.encoded_description}'>
                                 <img src='{$centreon_web_path}img/icons/chart.png' class='ico-18' title='{$title_graph}' />
                             </a>


### PR DESCRIPTION
Hi,

This PR follows #109 by @tanguyvda adding a tunable to toggle chart link/icon in the widget.
Depending on the use case, the chart icon is "useless", removing it then saves space / makes nicer output.

Thank you 👍 