### PR TITLE
fix(web): correctly compute localized downtime's datepickers

### DIFF
--- a/service-monitoring/src/action.php
+++ b/service-monitoring/src/action.php
@@ -303,7 +303,9 @@ try {
 
         //initializing datepicker and timepicker
         jQuery(".timepicker").each(function () {
-                $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+		if (! $(this).val()) {
+                	$(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+		}
         });
         jQuery("#start_time, #end_time").timepicker();
         initDatepicker();

--- a/service-monitoring/src/action.php
+++ b/service-monitoring/src/action.php
@@ -172,6 +172,10 @@ try {
 
             $template->assign('titleLabel', $title);
             $template->assign('submitLabel', _("Set Downtime"));
+            $template->assign('secondsLabel', _("seconds"));
+            $template->assign('minutesLabel', _("minutes"));
+            $template->assign('hoursLabel', _("hours"));
+            $template->assign('daysLabel', _("days"));
             $template->assign('defaultDuration', $defaultDuration);
             $template->assign($defaultScale . 'DefaultScale', 'selected');
             $template->display('downtime.ihtml');

--- a/service-monitoring/src/action.php
+++ b/service-monitoring/src/action.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -47,7 +48,8 @@ require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';
 session_start();
 
 try {
-    if (!isset($_SESSION['centreon']) ||
+    if (
+        !isset($_SESSION['centreon']) ||
         !isset($_REQUEST['cmd']) ||
         !isset($_REQUEST['selection'])
     ) {
@@ -71,13 +73,9 @@ try {
 
     $defaultDuration = 7200;
     $defaultScale = 's';
-    if (isset($centreon->optGen['monitoring_dwt_duration']) &&
-        $centreon->optGen['monitoring_dwt_duration']
-    ) {
+    if (!empty($centreon->optGen['monitoring_dwt_duration'])) {
         $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
-        if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
-            $centreon->optGen['monitoring_dwt_duration_scale']
-        ) {
+        if (!empty($centreon->optGen['monitoring_dwt_duration_scale'])) {
             $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
         }
     }
@@ -111,35 +109,31 @@ try {
 
             /* Default ack options */
             $persistent_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_persistent'])
-                && $centreon->optGen['monitoring_ack_persistent']
-            ) {
+            if (!empty($centreon->optGen['monitoring_ack_persistent'])) {
                 $persistent_checked = 'checked';
             }
             $template->assign('persistent_checked', $persistent_checked);
 
             $sticky_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_sticky']) && $centreon->optGen['monitoring_ack_sticky']) {
+            if (!empty($centreon->optGen['monitoring_ack_sticky'])) {
                 $sticky_checked = 'checked';
             }
             $template->assign('sticky_checked', $sticky_checked);
 
             $notify_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_notify']) && $centreon->optGen['monitoring_ack_notify']) {
+            if (!empty($centreon->optGen['monitoring_ack_notify'])) {
                 $notify_checked = 'checked';
             }
             $template->assign('notify_checked', $notify_checked);
 
             $process_service_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_svc']) && $centreon->optGen['monitoring_ack_svc']) {
+            if (!empty($centreon->optGen['monitoring_ack_svc'])) {
                 $process_service_checked = 'checked';
             }
             $template->assign('process_service_checked', $process_service_checked);
 
             $force_active_checked = '';
-            if (isset($centreon->optGen['monitoring_ack_active_checks'])
-                && $centreon->optGen['monitoring_ack_active_checks']
-            ) {
+            if (!empty($centreon->optGen['monitoring_ack_active_checks'])) {
                 $force_active_checked = 'checked';
             }
             $template->assign('force_active_checked', $force_active_checked);
@@ -158,30 +152,28 @@ try {
             /* Default downtime options */
             $process_service_checked = '';
             $fixed_checked = '';
-            if (isset($centreon->optGen['monitoring_dwt_fixed']) && $centreon->optGen['monitoring_dwt_fixed']) {
+            if (!empty($centreon->optGen['monitoring_dwt_fixed'])) {
                 $fixed_checked = 'checked';
             }
             $template->assign('fixed_checked', $fixed_checked);
 
-            if (isset($centreon->optGen['monitoring_dwt_svc']) && $centreon->optGen['monitoring_dwt_svc']) {
+            if (!empty($centreon->optGen['monitoring_dwt_svc'])) {
                 $process_service_checked = 'checked';
             }
             $template->assign('process_service_checked', $process_service_checked);
-
             $template->assign('defaultMessage', sprintf(_('Downtime set by %s'), $centreon->user->alias));
-
             $template->assign('titleLabel', $title);
             $template->assign('submitLabel', _("Set Downtime"));
-            $template->assign('secondsLabel', _("seconds"));
-            $template->assign('minutesLabel', _("minutes"));
-            $template->assign('hoursLabel', _("hours"));
-            $template->assign('daysLabel', _("days"));
+            $template->assign('sDurationLabel', _("seconds"));
+            $template->assign('mDurationLabel', _("minutes"));
+            $template->assign('hDurationLabel', _("hours"));
+            $template->assign('dDurationLabel', _("days"));
             $template->assign('defaultDuration', $defaultDuration);
             $template->assign($defaultScale . 'DefaultScale', 'selected');
             $template->display('downtime.ihtml');
         }
     } else {
-        $command = "";
+        $command = '';
         $isSvcCommand = false;
         switch ($cmd) {
             /* service: schedule check */
@@ -243,7 +235,7 @@ try {
                 throw new Exception('Unknown command');
                 break;
         }
-        if ($command != "") {
+        if ($command != '') {
             $externalCommandMethod = 'set_process_command';
             if (method_exists($externalCmd, 'setProcessCommand')) {
                 $externalCommandMethod = 'setProcessCommand';
@@ -260,7 +252,7 @@ try {
                     $hostname = $hostObj->getHostName($hostId);
                     $svcDesc = $svcObj->getServiceDesc($svcId);
                     if ($isSvcCommand === true) {
-                        $cmdParam = $hostname . ";" . $svcDesc;
+                        $cmdParam = $hostname . ';' . $svcDesc;
                     } else {
                         $cmdParam = $hostname;
                     }
@@ -278,7 +270,7 @@ try {
         $result = 1;
     }
 } catch (Exception $e) {
-    echo $e->getMessage() . "<br/>";
+    echo $e->getMessage() . '<br/>';
 }
 
 ?>
@@ -307,9 +299,12 @@ try {
 
         //initializing datepicker and timepicker
         jQuery(".timepicker").each(function () {
-		if (! $(this).val()) {
-                	$(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
-		}
+            if (!$(this).val()) {
+                $(this).val(moment().tz(localStorage.getItem('realTimezone')
+                    ? localStorage.getItem('realTimezone')
+                    : moment.tz.guess()).format("HH:mm")
+                );
+            }
         });
         jQuery("#start_time, #end_time").timepicker();
         initDatepicker();

--- a/service-monitoring/src/action.php
+++ b/service-monitoring/src/action.php
@@ -69,21 +69,17 @@ try {
     $successMsg = _("External Command successfully submitted... Exiting window...");
     $result = 0;
 
-    //retrieving the default timezone is the user didn't choose one
-    $gmt = $centreon->user->getMyGMT();
-    if (!$gmt) {
-        $gmt = date_default_timezone_get();
-    }
-
     $defaultDuration = 7200;
     $defaultScale = 's';
-    $duration = $defaultDuration;
-    if ($defaultScale == 'm') {
-        $duration *= 60;
-    } elseif ($defaultScale == 'h') {
-        $duration *= 3600;
-    } elseif ($defaultScale == 'd') {
-        $duration *= 86400;
+    if (isset($centreon->optGen['monitoring_dwt_duration']) &&
+        $centreon->optGen['monitoring_dwt_duration']
+    ) {
+        $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+        if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
+            $centreon->optGen['monitoring_dwt_duration_scale']
+        ) {
+            $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
+        }
     }
 
     if ($cmd == 72 || $cmd == 75 || $cmd == 70 || $cmd == 74) {
@@ -152,12 +148,6 @@ try {
             $template->assign('submitLabel', _("Acknowledge"));
             $template->display('acknowledge.ihtml');
         } elseif ($cmd == 75 || $cmd == 74) {
-            $hourStart = $centreon->CentreonGMT->getDate("H", time(), $gmt);
-            $minuteStart = $centreon->CentreonGMT->getDate("i", time(), $gmt);
-
-            $hourEnd = $centreon->CentreonGMT->getDate("H", time() + $duration, $gmt);
-            $minuteEnd = $centreon->CentreonGMT->getDate("i", time() + $duration, $gmt);
-
             $template->assign('downtimeHostSvcLabel', _("Set downtime on services of hosts"));
             if ($cmd == 75) {
                 $title = _("Host Downtime");
@@ -182,19 +172,8 @@ try {
 
             $template->assign('titleLabel', $title);
             $template->assign('submitLabel', _("Set Downtime"));
-            $template->assign('defaultSecondDuration', $defaultScale == 's' ? $defaultDuration : '0');
-            $template->assign('defaultHourDuration', $defaultScale == 'h' ? $defaultDuration : '0');
-            $template->assign('defaultMinuteDuration', $defaultScale == 'm' ? $defaultDuration : '0');
-            $template->assign('defaultDayDuration',  $defaultScale == 'd' ? $defaultDuration : '0');
-            $template->assign('duration', $duration); // In seconds
-            $template->assign('secondsLabel', _("seconds"));
-            $template->assign('daysLabel', _("days"));
-            $template->assign('hoursLabel', _("hours"));
-            $template->assign('minutesLabel', _("minutes"));
-            $template->assign('defaultHourStart', $hourStart);
-            $template->assign('defaultMinuteStart', $minuteStart);
-            $template->assign('defaultHourEnd', $hourEnd);
-            $template->assign('defaultMinuteEnd', $minuteEnd);
+            $template->assign('defaultDuration', $defaultDuration);
+            $template->assign($defaultScale . 'DefaultScale', 'selected');
             $template->display('downtime.ihtml');
         }
     } else {
@@ -323,10 +302,13 @@ try {
         });
 
         //initializing datepicker and timepicker
-        initDatepicker("datepicker", "yy/mm/dd", "0");
+        jQuery(".timepicker").each(function () {
+                $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+        });
         jQuery("#start_time, #end_time").timepicker();
-
+        initDatepicker();
         turnOnEvents();
+        updateEndTime();
     });
 
     function closeBox()
@@ -362,15 +344,11 @@ try {
     function toggleDurationField()
     {
         if (jQuery("[name=fixed]").is(':checked')) {
-            jQuery("[name=dayduration]").attr('disabled', true);
-            jQuery("[name=hourduration]").attr('disabled', true);
-            jQuery("[name=minuteduration]").attr('disabled', true);
-            jQuery("[name=secondduration]").attr('disabled', true);
+            jQuery("[name=duration]").attr('disabled', true);
+            jQuery("[name=duration_scale]").attr('disabled', true);
         } else {
-            jQuery("[name=dayduration]").removeAttr('disabled');
-            jQuery("[name=hourduration]").removeAttr('disabled');
-            jQuery("[name=minuteduration]").removeAttr('disabled');
-            jQuery("[name=secondduration]").removeAttr('disabled');
+            jQuery("[name=duration]").removeAttr('disabled');
+            jQuery("[name=duration_scale]").removeAttr('disabled');
         }
     }
 </script>

--- a/service-monitoring/src/downtime.ihtml
+++ b/service-monitoring/src/downtime.ihtml
@@ -29,10 +29,10 @@
 			<td class="FormRowValue">
 				<input type='text' id='duration' name='duration' width='30' value='{$defaultDuration}' />
 				<select id="duration_scale" name="duration_scale">
-					<option value="s" {$sDefaultScale}>Seconds</option>
-					<option value="m" {$mDefaultScale}>Minutes</option>
-					<option value="h" {$hDefaultScale}>Hours</option>
-					<option value="d" {$dDefaultScale}>Days</option>
+					<option value="s" {$sDefaultScale}>{$secondsLabel}</option>
+					<option value="m" {$mDefaultScale}>{$minutesLabel}</option>
+					<option value="h" {$hDefaultScale}>{$hoursLabel}</option>
+					<option value="d" {$dDefaultScale}>{$daysLabel}</option>
 				</select>
 			</td>
 		</tr>

--- a/service-monitoring/src/downtime.ihtml
+++ b/service-monitoring/src/downtime.ihtml
@@ -5,7 +5,6 @@
 				<h3>{$titleLabel}</h3>
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$startLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
@@ -14,7 +13,6 @@
 				<input type='hidden' class='alternativeDate' id='altDateStart' size='10' name="alternativeDateStart" />
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$endLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
@@ -23,27 +21,24 @@
 				<input type='hidden' class='alternativeDate' id='altDateEnd' size='10' name="alternativeDateEnd" />
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$durationLabel}</td>
 			<td class="FormRowValue">
 				<input type='text' id='duration' name='duration' width='30' value='{$defaultDuration}' />
 				<select id="duration_scale" name="duration_scale">
-					<option value="s" {$sDefaultScale}>{$secondsLabel}</option>
-					<option value="m" {$mDefaultScale}>{$minutesLabel}</option>
-					<option value="h" {$hDefaultScale}>{$hoursLabel}</option>
-					<option value="d" {$dDefaultScale}>{$daysLabel}</option>
+					<option value="s" {$sDefaultScale}>{$sDurationLabel}</option>
+					<option value="m" {$mDefaultScale}>{$mDurationLabel}</option>
+					<option value="h" {$hDefaultScale}>{$hDurationLabel}</option>
+					<option value="d" {$dDefaultScale}>{$dDurationLabel}</option>
 				</select>
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$fixedLabel}</td>
 			<td class="FormRowValue">
 				<input type='checkbox' name='fixed' {$fixed_checked} />
 			</td>
 		</tr>
-
 		<tr>
 			<td class="FormRowField">{$authorLabel}</td>
 			<td class="FormRowValue">
@@ -63,7 +58,6 @@
 				<td class="FormRowField"><input type='checkbox' name='processServices' {$process_service_checked}/></td>
 			</tr>
 		{/if}
-
 	</table>
 	<div id="validForm">
 		<input type='hidden' name='selection' value='{$selection}' />

--- a/service-monitoring/src/downtime.ihtml
+++ b/service-monitoring/src/downtime.ihtml
@@ -1,8 +1,4 @@
-<link href="../../../Themes/Centreon-2/style.css" rel="stylesheet" type="text/css"/>
-<link href="../../../Themes/Centreon-2/jquery-ui/jquery-ui.css" rel="stylesheet" type="text/css"/>
 <form id='Form'>
-    <input type="hidden" id="duration_scale" value="s" />
-    <input type="hidden" id="duration" value="{$duration}" />
 	<table class="table">
 		<tr>
 			<td style="color: #00bfb3;" class ="FormHeader" colspan="2">
@@ -14,7 +10,7 @@
 			<td class="FormRowField">{$startLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
 				<input type='text' class="datepicker" id='downtimestart' name='start' value='' size='9' />
-				<input id="start_time" size="5" class="timepicker" name="start_time" type="text" value='{$defaultHourStart}:{$defaultMinuteStart}'>
+				<input id="start_time" size="5" class="timepicker" name="start_time" type="text" value=''>
 				<input type='hidden' class='alternativeDate' id='altDateStart' size='10' name="alternativeDateStart" />
 			</td>
 		</tr>
@@ -23,7 +19,7 @@
 			<td class="FormRowField">{$endLabel}<span style='color: red;'> *</span></td>
 			<td class="FormRowValue">
 				<input class="datepicker" type='text' id='downtimeend' name='end' value='' size='9' />
-				<input id="end_time" size="5" class="timepicker" name="end_time" type="text" value='{$defaultHourEnd}:{$defaultMinuteEnd}'>
+				<input id="end_time" size="5" class="timepicker" name="end_time" type="text" value=''>
 				<input type='hidden' class='alternativeDate' id='altDateEnd' size='10' name="alternativeDateEnd" />
 			</td>
 		</tr>
@@ -31,10 +27,13 @@
 		<tr>
 			<td class="FormRowField">{$durationLabel}</td>
 			<td class="FormRowValue">
-                <input type='text' name='dayduration' size='2' value='{$defaultDayDuration}' />&nbsp;{$daysLabel}
-                <input type='text' name='hourduration' size='2' value='{$defaultHourDuration}' />&nbsp;{$hoursLabel}
-                <input type='text' name='minuteduration' size='2' value='{$defaultMinuteDuration}' />&nbsp;{$minutesLabel}
-                <input type='text' name='secondduration' size='5' value='{$defaultSecondDuration}' />&nbsp;{$secondsLabel}
+				<input type='text' id='duration' name='duration' width='30' value='{$defaultDuration}' />
+				<select id="duration_scale" name="duration_scale">
+					<option value="s" {$sDefaultScale}>Seconds</option>
+					<option value="m" {$mDefaultScale}>Minutes</option>
+					<option value="h" {$hDefaultScale}>Hours</option>
+					<option value="d" {$dDefaultScale}>Days</option>
+				</select>
 			</td>
 		</tr>
 


### PR DESCRIPTION
## Description

Fix an issue where datetime of downtimes weren't correctly computed, when not using the english localization :
- the ending datepicker was not set properly and displayed unconsistent date
- adding a downtime on two days, did not actualize the starting date of the datepicker
- setting an end time before the start date was possible and resulted on useless downtime (not processed by centengine)

**Fixes** MON-3935 & https://github.com/centreon/centreon/pull/7606 from @UrBnW  + https://github.com/centreon/centreon/issues/5963 + https://github.com/centreon/centreon/issues/7337 + https://github.com/centreon/centreon/issues/8266 + #8362 + #8383.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Choose for example the french language.
- Select a default duration on the Administration > parameters > monitoring + duration
- Set a downtime from the monitoring > status > downtime + add downtime
    check that the start and end date and time are set properly.
    check that consistent values are displayed when changing the datepicker and timepicker values.
    check that the datepicker and timepicker are still consistent with the choosen language.

- Do the same from all the other available downtime form in the UI eg :
    status > monitoring > services + choose a resource + set a downtime from the toolbar
    status > monitoring > host + choose a resource + set a downtime from the toolbar
    ...

- Check that no errors are displayed in the logs