### PR TITLE
fix(widget): hide services if host is in downtime

### DIFF
--- a/service-monitoring/src/index.php
+++ b/service-monitoring/src/index.php
@@ -246,9 +246,9 @@ if (isset($preferences['notification_filter']) && $preferences['notification_fil
 
 if (isset($preferences['downtime_filter']) && $preferences['downtime_filter']) {
     if ($preferences['downtime_filter'] == 'downtime') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.scheduled_downtime_depth > 0 ');
+        $query = CentreonUtils::conditionBuilder($query, ' s.scheduled_downtime_depth > 0 OR h.scheduled_downtime_depth > 0 ');
     } elseif ($preferences['downtime_filter'] == 'ndowntime') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.scheduled_downtime_depth = 0 ');
+        $query = CentreonUtils::conditionBuilder($query, ' s.scheduled_downtime_depth = 0 AND h.scheduled_downtime_depth = 0 ');
     }
 }
 


### PR DESCRIPTION
Hi,

When widget is configured to hide services in downtime, let's hide not only services which have a proper downtimes, but also services related to hosts in downtime (as these services will then not notify).

Please backport at least up to 19.10.x.

Thank you 👍

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)