### PR TITLE
fix(UI) untick checkboxes after performing an action MON-5882

### DIFF
--- a/service-monitoring/src/toolbar.php
+++ b/service-monitoring/src/toolbar.php
@@ -135,10 +135,14 @@ jQuery( function() {
                 parent.jQuery('#widgetPopin').parent().remove();
                 var popin = parent.jQuery('<div id="widgetPopin">');
 
-                popin.centreonPopin({
+                if (popin.centreonPopin({
                   open:true,
                   url:url
-                  });
+                })) {
+                    $.each(checkValues.split(','), function(index, value) {
+                        localStorage.removeItem('w_sh_selection_' + value);
+                    });
+                }
 
             } else {
                 alert("<?php echo _('Please select one or more items'); ?>");


### PR DESCRIPTION
fix MON-5882

in latest versions, if you perform an action on one or more services, the checkboxes remain ticked which is not practical to say the least.

behavior before this patch :

- add the service-monitoring widget in a custom view
- enable the more action and pagination option in the widget parameters
- tick one or more services checkboxes
- perform an action like enable check in the more actions list
- a popup will appear and disappear (meaning the action has been done), but the checkboxes are still ticked.

after the patch

- add the service-monitoring widget in a custom view
- enable the more action and pagination option in the widget parameters
- tick one or more host's checkboxes
- perform an action like enable check in the more actions list
- a popup will appear and disappear (meaning the action has been done), but the checkboxes are not ticket anymore.

unlike the host-monitoring widget this one refreshes the table after the action has been done so you don't need to manually untick checkboxes (just need to remove the information from localstorage)