### PR TITLE
Added filter host and service categories

### DIFF
--- a/service-monitoring/configs.xml
+++ b/service-monitoring/configs.xml
@@ -40,6 +40,8 @@
     <preference label="Poller" name="poller" defaultValue="" type="poller"/>
     <preference label="Hostgroup" name="hostgroup" defaultValue="" type="hostGroupMulti"/>
     <preference label="Servicegroup" name="servicegroup" defaultValue="" type="serviceGroupMulti"/>
+    <preference label="Hostcategory" name="hostcategory" defaultValue="" type="hostCategoriesMulti"/>
+    <preference label="Servicecategory" name="servicecategory" defaultValue="" type="serviceCategoriesMulti"/>
     <preference label="Results" name="entries" defaultValue="10" type="range" min="10" max="100" step="10"/>
     <preference label="Output" name="output_search" defaultValue="" type="compare" />
     <preference label="Display Severities" name="display_severities" defaultValue="1" type="boolean" header="Columns"/>

--- a/service-monitoring/src/export.php
+++ b/service-monitoring/src/export.php
@@ -320,6 +320,56 @@ if (isset($preferences['servicegroup']) && $preferences['servicegroup']) {
         )"
     );
 }
+if (isset($preferences['hostcategory']) && $preferences['hostcategory']) {
+    $results = explode(',', $preferences['hostcategory']);
+    $queryHC = '';
+    foreach ($results as $result) {
+        if ($queryHC != '') {
+            $queryHC .= ', ';
+        }
+        $queryHC .= ":id_" . $result;
+        $mainQueryParameters[] = [
+            'parameter' => ':id_' . $result,
+            'value' => (int)$result,
+            'type' => PDO::PARAM_INT
+        ];
+    }
+    $query = CentreonUtils::conditionBuilder(
+        $query,
+        " s.host_id IN (
+            SELECT host_host_id
+            FROM " . $conf_centreon['db'] . ".hostcategories_relation
+            WHERE hostcategories_hc_id IN (" . $queryHC . ")
+        )"
+    );
+}
+if (isset($preferences['servicecategory']) && $preferences['servicecategory']) {
+    $results = explode(',', $preferences['servicecategory']);
+    $querySC = '';
+    foreach ($results as $result) {
+        if ($querySC != '') {
+            $querySC .= ', ';
+        }
+        $querySC .= ":id_" . $result;
+        $mainQueryParameters[] = [
+            'parameter' => ':id_' . $result,
+            'value' => (int)$result,
+            'type' => PDO::PARAM_INT
+        ];
+    }
+    $query = CentreonUtils::conditionBuilder(
+        $query,
+        " s.service_id IN (
+            SELECT service_id
+            FROM " . $conf_centreon['db'] . ".service
+            WHERE service_template_model_stm_id IN (
+              SELECT service_service_id
+              FROM " . $conf_centreon['db'] . ".service_categories_relation
+              WHERE sc_id IN (" . $querySC . ")
+            )
+        )"
+    );
+}
 if  (!empty($preferences['criticality_filter'])) {
     $tab = explode(',', $preferences['criticality_filter']);
     $labels = [];

--- a/service-monitoring/src/index.php
+++ b/service-monitoring/src/index.php
@@ -317,6 +317,56 @@ if (isset($preferences['servicegroup']) && $preferences['servicegroup']) {
         )"
     );
 }
+if (isset($preferences['hostcategory']) && $preferences['hostcategory']) {
+    $results = explode(',', $preferences['hostcategory']);
+    $queryHC ='';
+    foreach ($results as $result) {
+        if ($queryHC != '') {
+            $queryHC .= ', ';
+        }
+        $queryHC .= ":id_" . $result;
+        $mainQueryParameters[] = [
+            'parameter' => ':id_' . $result,
+            'value' => (int)$result,
+            'type' => PDO::PARAM_INT
+        ];
+    }
+    $query = CentreonUtils::conditionBuilder(
+        $query,
+        " s.host_id IN (
+            SELECT host_host_id
+            FROM " . $conf_centreon['db'] . ".hostcategories_relation
+            WHERE hostcategories_hc_id IN (" . $queryHC . ")
+        )"
+    );
+}
+if (isset($preferences['servicecategory']) && $preferences['servicecategory']) {
+    $results = explode(',', $preferences['servicecategory']);
+    $querySC ='';
+    foreach ($results as $result) {
+        if ($querySC != '') {
+            $querySC .= ', ';
+        }
+        $querySC .= ":id_" . $result;
+        $mainQueryParameters[] = [
+            'parameter' => ':id_' . $result,
+            'value' => (int)$result,
+            'type' => PDO::PARAM_INT
+        ];
+    }
+    $query = CentreonUtils::conditionBuilder(
+        $query,
+        " s.service_id IN (
+            SELECT service_id
+            FROM " . $conf_centreon['db'] . ".service
+            WHERE service_template_model_stm_id IN (
+              SELECT service_service_id
+              FROM " . $conf_centreon['db'] . ".service_categories_relation
+              WHERE sc_id IN (" . $querySC . ")
+            )
+        )"
+    );
+}
 if  (!empty($preferences['criticality_filter'])) {
     $tab = explode(',', $preferences['criticality_filter']);
     $labels = [];


### PR DESCRIPTION
# Pull Request Template

## Description

Hello,

This functionality will add host and service category filtering to this widget.

In order for the service category to work, the related PR in centreon must be merged.

**Fixes** #78 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a new view with a new widget service-monitoring
2. In the widget preferences, set "Host Category" or "Service Category" filter
3. Check if the filter is correctly applied in the widget list

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
