### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/service-monitoring/configs.xml
+++ b/service-monitoring/configs.xml
@@ -4,7 +4,7 @@
   <email>contact@centreon.com</email>
   <website>http://www.centreon.com</website>
   <description>This interactive service event console widget displays the services status and allows to act on them (acknowledge, add dowtime, etc.). Multiple parameters allow to select which services to display (based on their name, hostgroup, status, etc.) or which columns (name, alias, status, duration, output, etc.).</description>
-  <version>21.10.0-beta.1</version>
+  <version>21.10.0</version>
   <keywords>centreon, widget, service, monitoring</keywords>
   <screenshot></screenshot>
   <thumbnail>./widgets/service-monitoring/resources/centreon-logo.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix