### PR TITLE
feat(ui): Applying dark mode to the widget

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",
-    "squizlabs/php_codesniffer": "^3.5"
+    "squizlabs/php_codesniffer": "^3.6"
   },
   "config": {
     "secure-http": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bc07d101c5e5a1e3255d173a6ce9b72",
+    "content-hash": "f0b8c8cf97b6f9d8b857960f5dbb82d8",
     "packages": [],
     "packages-dev": [
         {
@@ -1595,16 +1595,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
@@ -1647,7 +1647,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1842,5 +1842,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/service-monitoring/index.php
+++ b/service-monitoring/index.php
@@ -55,6 +55,11 @@ try {
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
+    $variablesThemeCSS = match ($centreon->user->theme) {
+        'light' => "Generic-theme",
+        'dark' => "Centreon-Dark",
+        default => throw new \Exception('Unknown user theme : ' . $centreon->user->theme),
+    };
 } catch (Exception $e) {
     echo $e->getMessage() . "<br/>";
     exit;
@@ -74,5 +79,6 @@ if ($preferences['more_views']) {
     $bMoreViews = $preferences['more_views'];
 }
 $template->assign('more_views', $bMoreViews);
+$template->assign('theme', $variablesThemeCSS);
 
 $template->display('index.ihtml');

--- a/service-monitoring/src/index.ihtml
+++ b/service-monitoring/src/index.ihtml
@@ -2,8 +2,9 @@
     <head>
 	<title>Service Monitoring</title>
 	<link href="../../include/common/javascript/jquery/plugins/pagination/pagination.css" rel="stylesheet" type="text/css"/>
-    <link href="../../Themes/Centreon-2/Color/blue_css.php" rel="stylesheet" type="text/css"/>
-    <link href="../../Themes/Centreon-2/style.css" rel="stylesheet" type="text/css"/>
+        <link href="../../Themes/Generic-theme/style.css" rel="stylesheet" type="text/css"/>
+        <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" type="text/css"/>
+        <link href="../../Themes/{$theme}/variables.css"  rel="stylesheet" type="text/css"/>
     </head>
     <body>
         {if $preferences.more_views == 1}

--- a/service-monitoring/src/index.ihtml
+++ b/service-monitoring/src/index.ihtml
@@ -4,7 +4,8 @@
 	<link href="../../include/common/javascript/jquery/plugins/pagination/pagination.css" rel="stylesheet" type="text/css"/>
         <link href="../../Themes/Generic-theme/style.css" rel="stylesheet" type="text/css"/>
         <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" type="text/css"/>
-        <link href="../../Themes/{$theme}/variables.css"  rel="stylesheet" type="text/css"/>
+        <link href="../../Themes/{($theme === "Generic-theme") ? ($theme|cat:"/Variables-css") : $theme}/variables.css"
+              rel="stylesheet" type="text/css"/>
     </head>
     <body>
         {if $preferences.more_views == 1}


### PR DESCRIPTION
## Description

Changing css links matching the new file structure to apply dark mode and upgrading code sniffer's version so it can support the "match" statement.

**Fixes** # MON-12623

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
