### PR TITLE
Update table.ihtml

### DIFF
--- a/service-monitoring/src/table.ihtml
+++ b/service-monitoring/src/table.ihtml
@@ -59,28 +59,28 @@
                     {if $elem.hostname != $previous}
                         <td class='ListColLeft'>
                             {if $elem.icon_image != ''}
-                                <img src='{$centreon_web_path}img/media/{$elem.icon_image}' width='16' height='16' style ='padding-right:3px;' />
+                                <img src='/{$centreon_web_path}/img/media/{$elem.icon_image}' width='16' height='16' style ='padding-right:3px;' />
                             {else}
-                                <img src='{$centreon_web_path}img/icones/1x1/blank.gif' width='16' height='16' style ='padding-right:3px;' />
+                                <img src='/{$centreon_web_path}/img/icones/1x1/blank.gif' width='16' height='16' style ='padding-right:3px;' />
                             {/if}
                             <span class="state_badge" style='background-color: {$elem.hcolor};'></span>
                             <a href='{$elem.h_details_uri}' target=_blank>{$host_name}</a>
                         </td>
                         <td class='ListColRight'>
                             <div style='float: right;'>
-                                {if $elem.h_scheduled_downtime_depth}<img src='{$centreon_web_path}img/icons/warning.png' class="ico-18">{/if}
-                                {if $elem.h_acknowledged}<img src='{$centreon_web_path}img/icones/16x16/worker.gif' class="ico-18">{/if}
-                                {if $elem.h_active_checks == 0}<img src='{$centreon_web_path}img/icons/never_checked.png' class="ico-18">{/if}
-                                {if $elem.h_passive_checks}<img src='{$centreon_web_path}img/icons/passive_check.png' class="ico-18">{/if}
-                                {if $elem.h_notify == 0}<img src='{$centreon_web_path}img/icons/notifications_off.png' class="ico-18">{/if}
+                                {if $elem.h_scheduled_downtime_depth}<img src='/{$centreon_web_path}/img/icons/warning.png' class="ico-18">{/if}
+                                {if $elem.h_acknowledged}<img src='/{$centreon_web_path}/img/icones/16x16/worker.gif' class="ico-18">{/if}
+                                {if $elem.h_active_checks == 0}<img src='/{$centreon_web_path}/img/icons/never_checked.png' class="ico-18">{/if}
+                                {if $elem.h_passive_checks}<img src='/{$centreon_web_path}/img/icons/passive_check.png' class="ico-18">{/if}
+                                {if $elem.h_notify == 0}<img src='/{$centreon_web_path}/img/icons/notifications_off.png' class="ico-18">{/if}
                                 {if $elem.h_action_url}
                                     <a target=_blank href='{$elem.h_action_url}'>
-                                        <img src='{$centreon_web_path}img/icons/star-full.png' class="ico-16">
+                                        <img src='/{$centreon_web_path}/img/icons/star-full.png' class="ico-16">
                                     </a>
                                 {/if}
                                 {if $elem.h_notes_url}
                                     <a target=_blank href='{$elem.h_notes_url}'>
-                                        <img src='{$centreon_web_path}img/icons/link.png' class="ico-14">
+                                        <img src='/{$centreon_web_path}/img/icons/link.png' class="ico-14">
                                     </a>
                                 {/if}
                             </div>
@@ -93,7 +93,7 @@
 	                <td class=''>
 			{if $preferences.display_chart_icon && $elem.perfdata != ""}
 			    <a target=_blank href='{$elem.s_graph_uri}'>
-                                <img src='{$centreon_web_path}img/icons/chart.png' class='ico-18' />
+                                <img src='/{$centreon_web_path}/img/icons/chart.png' class='ico-18' />
                             </a>
 			{/if}
                         {if $preferences.display_status == 0}
@@ -107,19 +107,19 @@
                     </td>
                     <td class='ListColRight'>
                         <div style='float: right;'>
-                            {if $elem.s_scheduled_downtime_depth}<img src='{$centreon_web_path}img/icons/warning.png' class="ico-18">{/if}
-                            {if $elem.s_acknowledged}<img src='{$centreon_web_path}img/icons/technician.png' class="ico-18">{/if}
-                            {if $elem.s_active_checks == 0 && $elem.s_passive_checks == 0}<img src='{$centreon_web_path}img/icons/never_checked.png' class="ico-18">{/if}
-                            {if $elem.s_passive_checks == 1 && $elem.s_active_checks == 0}<img src='{$centreon_web_path}img/icons/passive_check.png' class="ico-18">{/if}
-                            {if $elem.s_notify == 0}<img src='{$centreon_web_path}img/icons/notifications_off.png' class="ico-18">{/if}
+                            {if $elem.s_scheduled_downtime_depth}<img src='/{$centreon_web_path}/img/icons/warning.png' class="ico-18">{/if}
+                            {if $elem.s_acknowledged}<img src='/{$centreon_web_path}/img/icons/technician.png' class="ico-18">{/if}
+                            {if $elem.s_active_checks == 0 && $elem.s_passive_checks == 0}<img src='/{$centreon_web_path}/img/icons/never_checked.png' class="ico-18">{/if}
+                            {if $elem.s_passive_checks == 1 && $elem.s_active_checks == 0}<img src='/{$centreon_web_path}/img/icons/passive_check.png' class="ico-18">{/if}
+                            {if $elem.s_notify == 0}<img src='/{$centreon_web_path}/img/icons/notifications_off.png' class="ico-18">{/if}
 		                    {if $elem.s_action_url}
                                 <a target=_blank href='{$elem.s_action_url}'>
-                                    <img src='{$centreon_web_path}img/icons/star-full.png' class="ico-16">
+                                    <img src='/{$centreon_web_path}/img/icons/star-full.png' class="ico-16">
                                 </a>
                             {/if}
                             {if $elem.s_notes_url}
                                 <a target=_blank href='{$elem.s_notes_url}'>
-                                    <img src='{$centreon_web_path}img/icons/link.png' class="ico-14">
+                                    <img src='/{$centreon_web_path}/img/icons/link.png' class="ico-14">
                                 </a>
                             {/if}
                         </div>


### PR DESCRIPTION
# Pull Request Template

## Description

Image path with {$centreon_web_path} is not introduce with /. Even with centreon_web_path set to /centreon/ the variable is stripped from it for the widget.
Others widgets like centreon-widget-servicegroup-monitoring use this syntax

Changing the way {$centreon_web_path} is used for image to translate the web path right :
`<img src='{$centreon_web_path}img` => `<img src='centreonimg`
`<img src='/{$centreon_web_path}/img` => `<img src='/centreon/img`

**Fixes** #191

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (master)

Only tested issue in this centreon version

<h2> How this pull request can be tested ? </h2>

Custom View / Add Widget / Service Monitoring, then check if images (host, service, severity, passiv check) are correct

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
